### PR TITLE
feat(blocks): Add FeatureCard component with tests and stories

### DIFF
--- a/docs/stories/blocks/FeatureCard.stories.tsx
+++ b/docs/stories/blocks/FeatureCard.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FeatureCard } from '../../../src/blocks/feature-card/FeatureCard';
+import { Icon } from '@iconify/react';
+
+const meta = {
+  title: 'Blocks/Feature/FeatureCard',
+  component: FeatureCard,
+  tags: ['autodocs'],
+  argTypes: {
+    buttonVariant: {
+      control: 'select',
+      options: ['default', 'link', 'destructive', 'outline', 'secondary', 'ghost', 'primary']
+    }
+  },
+} satisfies Meta<typeof FeatureCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    id: 'feature-1',
+    heading: 'Feature Title',
+    content: 'This is a description of the feature. It can be multiple lines and provide more details about what this feature offers.',
+    buttonText: 'Learn More',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    id: 'feature-2',
+    heading: 'Feature with Icon',
+    content: 'This feature card includes an icon to make it more visually appealing and help users quickly identify the feature.',
+    buttonText: 'Get Started',
+    icon: <Icon icon="mdi:star" className="w-8 h-8" />,
+  },
+};
+
+export const SecondaryVariant: Story = {
+  args: {
+    id: 'feature-3',
+    heading: 'Secondary Button',
+    content: 'This card uses a secondary button variant for a different visual emphasis.',
+    buttonText: 'View Details',
+    buttonVariant: 'secondary',
+    icon: <Icon icon="mdi:information" className="w-8 h-8" />,
+  },
+};
+
+export const WithoutButton: Story = {
+  args: {
+    id: 'feature-4',
+    heading: 'No Button',
+    content: 'This feature card doesn\'t include a button, showing how it looks with just the heading and content.',
+    icon: <Icon icon="mdi:check-circle" className="w-8 h-8" />,
+  },
+};
+
+export const GridExample: Story = {
+  render: () => (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-[1200px]">
+      <FeatureCard 
+        id="grid-1"
+        heading="Responsive Design"
+        content="Built with mobile-first approach, ensuring perfect display across all devices."
+        buttonText="Learn More"
+        icon={<Icon icon="mdi:responsive" className="w-8 h-8" />}
+      />
+      <FeatureCard 
+        id="grid-2"
+        heading="Customizable"
+        content="Easily customize colors, spacing, and components to match your brand."
+        buttonText="View Options"
+        buttonVariant="secondary"
+        icon={<Icon icon="mdi:palette" className="w-8 h-8" />}
+      />
+      <FeatureCard 
+        id="grid-3"
+        heading="Dark Mode"
+        content="Built-in dark mode support with smooth transitions and theme switching."
+        buttonText="Try Dark Mode"
+        buttonVariant="outline"
+        icon={<Icon icon="mdi:theme-light-dark" className="w-8 h-8" />}
+      />
+    </div>
+  ),
+}; 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "references": [{ "path": "../tsconfig.node.json" }]
+} 

--- a/examples/feature-cards/FeatureCardsExample.tsx
+++ b/examples/feature-cards/FeatureCardsExample.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { BlockKitProvider } from '../../src';
+import { FeatureCard } from '../../src/components/FeatureCard';
+import { Icon } from '@iconify/react';
+
+export default function FeatureCardsExample() {
+  return (
+    <BlockKitProvider>
+      <div className="min-h-screen p-8">
+        <h1 className="text-3xl font-bold mb-8">Feature Cards Example</h1>
+        
+        {/* Grid of Feature Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <FeatureCard 
+            id="feature-1"
+            heading="Responsive Design"
+            content="Built with mobile-first approach, ensuring perfect display across all devices."
+            buttonText="Learn More"
+            icon={<Icon icon="mdi:responsive" className="w-8 h-8" />}
+          />
+          
+          <FeatureCard 
+            id="feature-2"
+            heading="Customizable"
+            content="Easily customize colors, spacing, and components to match your brand."
+            buttonText="View Options"
+            buttonVariant="secondary"
+            icon={<Icon icon="mdi:palette" className="w-8 h-8" />}
+          />
+          
+          <FeatureCard 
+            id="feature-3"
+            heading="Dark Mode"
+            content="Built-in dark mode support with smooth transitions and theme switching."
+            buttonText="Try Dark Mode"
+            buttonVariant="outline"
+            icon={<Icon icon="mdi:theme-light-dark" className="w-8 h-8" />}
+          />
+          
+          <FeatureCard 
+            id="feature-4"
+            heading="Accessibility"
+            content="WCAG 2.1 AA compliant components with keyboard navigation support."
+            buttonText="Accessibility Guide"
+            buttonVariant="ghost"
+            icon={<Icon icon="mdi:accessibility" className="w-8 h-8" />}
+          />
+          
+          <FeatureCard 
+            id="feature-5"
+            heading="Performance"
+            content="Optimized for speed with minimal bundle size and efficient rendering."
+            buttonText="Performance Metrics"
+            buttonVariant="primary"
+            icon={<Icon icon="mdi:speedometer" className="w-8 h-8" />}
+          />
+          
+          <FeatureCard 
+            id="feature-6"
+            heading="Documentation"
+            content="Comprehensive documentation with examples and API references."
+            buttonText="View Docs"
+            buttonVariant="link"
+            icon={<Icon icon="mdi:book-open-page-variant" className="w-8 h-8" />}
+          />
+        </div>
+      </div>
+    </BlockKitProvider>
+  );
+} 

--- a/examples/run-examples.tsx
+++ b/examples/run-examples.tsx
@@ -9,6 +9,7 @@ import FormExample from './basic/form';
 import ResponsiveExample from './basic/responsive';
 import App from './basic/app';
 import ThemeExample from './advanced/theme-example';
+import FeatureCardsExample from './feature-cards/FeatureCardsExample';
 
 // Define example components with metadata
 const examples = [
@@ -18,6 +19,7 @@ const examples = [
   { id: 'responsive', name: 'Responsive Example', component: ResponsiveExample },
   { id: 'app', name: 'App with Theme Toggle', component: App },
   { id: 'theme-example', name: 'Advanced Theme Example', component: ThemeExample },
+  { id: 'feature-cards', name: 'Feature Cards', component: FeatureCardsExample },
 ];
 
 function ExampleRunner() {

--- a/src/__tests__/blocks/feature-card/FeatureCard.test.tsx
+++ b/src/__tests__/blocks/feature-card/FeatureCard.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FeatureCard } from '../../../blocks/feature-card/FeatureCard';
+import { Icon } from '@iconify/react';
+
+describe('FeatureCard', () => {
+  it('renders with basic props', () => {
+    render(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+      />
+    );
+
+    expect(screen.getByText('Test Heading')).toBeInTheDocument();
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('renders with button when buttonText is provided', () => {
+    render(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+        buttonText="Click Me"
+      />
+    );
+
+    expect(screen.getByText('Click Me')).toBeInTheDocument();
+  });
+
+  it('renders with icon when provided', () => {
+    render(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+        icon={<Icon icon="mdi:star" className="w-8 h-8" />}
+      />
+    );
+
+    // Check if the icon container is present
+    expect(screen.getByTestId('icon-container')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+        className="custom-class"
+      />
+    );
+
+    const card = screen.getByTestId('feature-card');
+    expect(card).toHaveClass('custom-class');
+  });
+
+  it('renders with different button variants', () => {
+    const { rerender } = render(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+        buttonText="Default Button"
+      />
+    );
+
+    const defaultButton = screen.getByText('Default Button').closest('button');
+    expect(defaultButton).toHaveClass('bg-default');
+
+    rerender(
+      <FeatureCard
+        id="test-card"
+        heading="Test Heading"
+        content="Test content"
+        buttonText="Secondary Button"
+        buttonVariant="secondary"
+      />
+    );
+
+    const secondaryButton = screen.getByText('Secondary Button').closest('button');
+    expect(secondaryButton).toHaveClass('bg-default/40');
+  });
+}); 

--- a/src/blocks/feature-card/FeatureCard.tsx
+++ b/src/blocks/feature-card/FeatureCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { BlockContainer } from '../../composition/container/BlockContainer';
+import { TextBlock } from '../text-block/TextBlock';
+import { Button } from '../../components/Button';
+
+export interface FeatureCardProps {
+  id: string;
+  heading: string;
+  content: string;
+  buttonText?: string;
+  buttonVariant?: "default" | "link" | "destructive" | "outline" | "secondary" | "ghost" | "primary";
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+export const FeatureCard: React.FC<FeatureCardProps> = ({
+  id,
+  heading,
+  content,
+  buttonText,
+  buttonVariant = "default",
+  icon,
+  className = "",
+}) => (
+  <BlockContainer 
+    id={id} 
+    className={`p-6 bg-card rounded-lg border shadow-sm hover:shadow-md transition-shadow duration-200 ${className}`}
+    spacing="md"
+    data-testid="feature-card"
+  >
+    {icon && (
+      <div className="mb-4 text-primary" data-testid="icon-container">
+        {icon}
+      </div>
+    )}
+    <TextBlock
+      id={`${id}-heading`}
+      text={heading}
+      type="heading1"
+    />
+    <TextBlock
+      id={`${id}-content`}
+      text={content}
+      type="paragraph"
+    />
+    {buttonText && (
+      <Button 
+        variant={buttonVariant} 
+        className="w-full sm:w-auto"
+      >
+        {buttonText}
+      </Button>
+    )}
+  </BlockContainer>
+); 

--- a/src/blocks/feature-card/index.ts
+++ b/src/blocks/feature-card/index.ts
@@ -1,0 +1,1 @@
+export * from './FeatureCard'; 

--- a/src/blocks/index.ts
+++ b/src/blocks/index.ts
@@ -7,6 +7,7 @@ export * from './embed-block';
 export * from './interactive-block';
 export * from './media-block';
 export * from './text-block';
+export * from './feature-card';
 
 // Re-export Button from components for backward compatibility
 import { Button } from '../components/Button';


### PR DESCRIPTION
## Description
Added a new FeatureCard component to the block kit library. This component provides a flexible and reusable card layout that can be used to showcase features, services, or any content that benefits from a card-based presentation. The component supports customization through various props including heading, content, icon, and button options.

## Type of change
- [x] New feature

## How has this been tested?
The component has been thoroughly tested with a comprehensive test suite that covers:
- Basic rendering of the component with required props
- Button rendering and variant handling
- Icon rendering functionality
- Custom class name application
- Different button variants and their styling

All tests are passing and the component has been verified in Storybook with various configurations.

## Screenshots (if applicable)
https://jam.dev/c/d9d97228-c3c2-4b85-bb3f-f32d9758cc85

## Checklist
- [x] My code follows the project's coding style
- [x] I have added tests for my changes
- [x] All tests pass locally
- [x] I have updated documentation accordingly (via Storybook stories)
- [x] My changes don't introduce new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new Feature Card component, allowing display of content with headings, icons, and customizable buttons.
  - Added multiple button variants and icon support for Feature Cards.
  - Provided a responsive grid layout example showcasing multiple Feature Cards.
- **Documentation**
  - Added Storybook stories demonstrating various Feature Card configurations.
- **Tests**
  - Introduced comprehensive tests for the Feature Card component to ensure correct rendering and behavior.
- **Chores**
  - Updated TypeScript configuration to support new documentation and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->